### PR TITLE
Fix: handle case where response is a lambda (plus eq->eql fixup)

### DIFF
--- a/clath.lisp
+++ b/clath.lisp
@@ -67,7 +67,7 @@ login manager is developed.
           (if extension
               (funcall lapp (repath-clack-env env extension))
               (let ((res (funcall app env)))
-                (if (eq 403 (car res))
+                (if (and (consp res) (eql 403 (car res)))
                     (not-logged-page env res)
                     res))))))))
 


### PR DESCRIPTION
LACK responses can be either a cons or a lambda.  This fixes the not-logged-in check for the case where it is the latter (such a response, I think, can reasonably be assumed to not be a 403)

I also changed the EQ operator to EQL, which is correct for number comparisons [1].

1. http://www.lispworks.com/documentation/lw50/CLHS/Body/f_eq.htm