### PR TITLE
Fixups for LinkedIn auth.

### DIFF
--- a/bottom.lisp
+++ b/bottom.lisp
@@ -45,7 +45,9 @@
          (alglist '(:hs256 :hs384 :hs512 :rs256 :rs384 :rs512 :ps256 :ps384 :ps512)))
     (dolist (key (cdr (assoc :keys data)))
       (when-let ((kobj (get-jwk-key key))
-                 (alg (find (cdr (assoc :alg key)) alglist :test #'string-equal)))
+                 (alg (or
+                       (find (cdr (assoc :alg key)) alglist :test #'string-equal)
+                       :rs256)))
         (push (cons (cdr (assoc :kid key)) kobj) res)
         (push (cons (cdr (assoc :kid key)) alg) algs)))
     (values (nreverse res) (nreverse algs))))

--- a/providers.lisp
+++ b/providers.lisp
@@ -62,8 +62,9 @@
      "linkedin"
      :auth-endpoint "https://www.linkedin.com/uas/oauth2/authorization"
      :token-endpoint "https://www.linkedin.com/uas/oauth2/accessToken"
-     :userinfo-endpoint "https://api.linkedin.com/v1/people/~"
-     :auth-scope "")
+     :userinfo-endpoint "https://api.linkedin.com/v2/userinfo"
+     :jwks-uri "https://www.linkedin.com/oauth/openid/jwks"
+     :auth-scope "openid email")
     :yahoo
     (:string "yahoo"
      :auth-endpoint "https://api.login.yahoo.com/oauth2/request_auth"
@@ -117,8 +118,7 @@
 (defmethod request-user-info ((provider (eql :linkedin)) access-token)
   (cl-json:decode-json-from-string
    (drakma:http-request (getf (provider-info provider) :userinfo-endpoint)
-                        :parameters `(("oauth2_access_token" . ,access-token)
-                                      ("format" . "json"))
+                        :parameters `(("oauth2_access_token" . ,access-token))
                         :method :get
                         :user-agent (user-agent provider))))
 


### PR DESCRIPTION
API changes:

1. Updated `userinfo-endpoint`
2. Added `jwks-uri`
3. Added minimal `auth-scope`s, which must now be explicit

Furthermore, I have added an ugly hack to assume `RS256` when no `alg` is specified for the JWK.